### PR TITLE
Pass edge Id 

### DIFF
--- a/redisgraph/query_result.py
+++ b/redisgraph/query_result.py
@@ -111,7 +111,7 @@ class QueryResult(object):
         src_node_id = float(cell[2])
         dest_node_id = float(cell[3])
         properties = self.parse_entity_properties(cell[4])
-        return Edge(src_node_id, relation, dest_node_id, properties=properties)
+        return Edge(src_node_id, relation, dest_node_id, edge_id=edge_id, properties=properties)
 
     def parse_scalar(self, cell):
         scalar_type = int(cell[0])


### PR DESCRIPTION
Pass `edge_id` while parsing the edge data.

As seen in the [Relationship uniqueness in patterns](https://oss.redislabs.com/redisgraph/known_limitations/) in the known limitations section, `id` can be seen as the only field that can distinguish the edges that doesn't have any `properties` and `labels` attached to them.

So Edge `Id`s will be helpful to process the relationships in the graph.