### PR TITLE
Assign local variable `scalar` and compare bytes of two values

### DIFF
--- a/redisgraph/query_result.py
+++ b/redisgraph/query_result.py
@@ -116,6 +116,7 @@ class QueryResult(object):
     def parse_scalar(self, cell):
         scalar_type = int(cell[0])
         value = cell[1]
+        scalar = None
 
         if scalar_type == ResultSetScalarTypes.PROPERTY_NULL:
             scalar = None
@@ -127,9 +128,9 @@ class QueryResult(object):
             scalar = int(value)
 
         elif scalar_type == ResultSetScalarTypes.PROPERTY_BOOLEAN:
-            if value == "true":
+            if value == b"true":
                 scalar = True
-            elif value == "false":
+            elif value == b"false":
                 scalar = False
             else:
                 print("Unknown boolean type\n")

--- a/redisgraph/query_result.py
+++ b/redisgraph/query_result.py
@@ -128,9 +128,10 @@ class QueryResult(object):
             scalar = int(value)
 
         elif scalar_type == ResultSetScalarTypes.PROPERTY_BOOLEAN:
-            if value == b"true":
+            value = value.decode() if isinstance(value, bytes) else value
+            if value == "true":
                 scalar = True
-            elif value == b"false":
+            elif value == "false":
                 scalar = False
             else:
                 print("Unknown boolean type\n")


### PR DESCRIPTION
Squashed Commit: 
``` 
* Assign a val to local variable `scalar` before returning
* Compare bytes of two values
```

Long:
1) There are two cases where we get an exception `UnboundLocalError: local variable 'scalar' referenced before assignment`
    -  We find the type to be `boolean` and find the value not being `true` or `false` (Happens when we compare bytes with a string) and we reach the return statement and we get the above exception since we haven't defined `scalar` in the outer scope.
    - When the `scalar_type` is `ResultSetScalarTypes.PROPERTY_UNKNOWN`, we reach the final statement and return `scalar` which hasn't been defined.
2) We have to compare byte response with byte string as `b'true'` is not equal to `true`, we always return the boolean values as `None` since we have reached the `else` statement.

Short:
- 1st commit solves `local variable 'UnboundLocalError: scalar' referenced before assignment` by assigning a value to the variable.
- 2nd commit compares byte values and returns the appropriate values instead of None.