### PR TITLE
Fix the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ result = redis_graph.query(query)
 # Print resultset
 result.pretty_print()
 
-# Iterate through resultset, skip header row at position 0
-for record in result.result_set[1:]:
+# Iterate through resultset
+for record in result.result_set:
 	person_name = record[0]
 	person_age = record[1]
 	visit_purpose = record[2]


### PR DESCRIPTION
When I was running through the example, I noticed that `result_set` does not include the header. I updated the example code so that it wouldn't skip the first entry, since that might create bugs for new users following the example.