### PR TITLE
quote_string handles empty string

### DIFF
--- a/redisgraph/util.py
+++ b/redisgraph/util.py
@@ -15,6 +15,8 @@ def quote_string(v):
     """
     if not isinstance(v, str):
         return v
+    if len(v) == 0:
+        return '""'
 
     if v[0] != '"':
         v = '"' + v


### PR DESCRIPTION
This PR fixes a bug in quote_string function.
The function addressed the first character in a string (`v[0]`), and cause an application crash when given an empty string.
This fix returns an empty quoted string, in case of an empty string.