### PR TITLE
Edge can be str() after returning from QueryResult

### DIFF
--- a/redisgraph/edge.py
+++ b/redisgraph/edge.py
@@ -29,7 +29,7 @@ class Edge(object):
     def __str__(self):
         # Source node.
         if isinstance(self.src_node, Node):
-            res = '(' + self.src_node.alias + ')'
+            res = str(self.src_node)
         else:
             res = '()'
 
@@ -44,7 +44,7 @@ class Edge(object):
 
         # Dest node.
         if isinstance(self.dest_node, Node):
-            res += '(' + self.dest_node.alias + ')'
+            res += str(self.dest_node)
         else:
             res += '()'
 

--- a/redisgraph/edge.py
+++ b/redisgraph/edge.py
@@ -1,3 +1,5 @@
+from redisgraph import Node
+
 from .util import *
 
 class Edge(object):
@@ -26,7 +28,10 @@ class Edge(object):
 
     def __str__(self):
         # Source node.
-        res = '(' + self.src_node.alias + ')'
+        if isinstance(self.src_node, Node):
+            res = '(' + self.src_node.alias + ')'
+        else:
+            res = '()'
 
         # Edge
         res += "-["
@@ -38,7 +43,10 @@ class Edge(object):
         res += ']->'
 
         # Dest node.
-        res += '(' + self.dest_node.alias + ')'
+        if isinstance(self.dest_node, Node):
+            res += '(' + self.dest_node.alias + ')'
+        else:
+            res += '()'
 
         return res
 

--- a/redisgraph/query_result.py
+++ b/redisgraph/query_result.py
@@ -119,10 +119,10 @@ class QueryResult(object):
         # dest node ID offset (integer),
         # [[name, value, value type] X N]
 
-        edge_id = float(cell[0])
+        edge_id = int(cell[0])
         relation = self.graph.get_relation(cell[1])
-        src_node_id = float(cell[2])
-        dest_node_id = float(cell[3])
+        src_node_id = int(cell[2])
+        dest_node_id = int(cell[3])
         properties = self.parse_entity_properties(cell[4])
         return Edge(src_node_id, relation, dest_node_id, edge_id=edge_id, properties=properties)
 

--- a/test.py
+++ b/test.py
@@ -9,26 +9,26 @@ class TestStringMethods(unittest.TestCase):
 
     def test_graph_creation(self):
         redis_graph = Graph('social', self.r)
-        
+
         john = Node(label='person', properties={'name': 'John Doe', 'age': 33, 'gender': 'male', 'status': 'single'})
         redis_graph.add_node(john)
         japan = Node(label='country', properties={'name': 'Japan'})
-        
+
         redis_graph.add_node(japan)
         edge = Edge(john, 'visited', japan, properties={'purpose': 'pleasure'})
         redis_graph.add_edge(edge)
-        
+
         redis_graph.commit()
-        
+
         query = """MATCH (p:person)-[v:visited {purpose:"pleasure"}]->(c:country)
 				   RETURN p, v, c"""
-        
+
         result = redis_graph.query(query)
-        
+
         person = result.result_set[0][0]
         visit = result.result_set[0][1]
         country = result.result_set[0][2]
-        
+
         self.assertEqual(person, john)
         self.assertEqual(visit.properties, edge.properties)
         self.assertEqual(country, japan)
@@ -37,7 +37,7 @@ class TestStringMethods(unittest.TestCase):
         result = redis_graph.query(query)
         self.assertEqual([1, 2.3, "4", True, False, None], result.result_set[0][0])
 
-		# All done, remove graph.
+        # All done, remove graph.
         redis_graph.delete()
 
     def test_array_functions(self):
@@ -61,10 +61,8 @@ class TestStringMethods(unittest.TestCase):
 
         self.assertEqual([a, b], result.result_set[0][0])
 
-
         # All done, remove graph.
         redis_graph.delete()
-
 
     def test_path(self):
         redis_graph = Graph('social', self.r)
@@ -108,23 +106,31 @@ class TestStringMethods(unittest.TestCase):
         redis_graph.delete()
 
     def test_stringify_query_result(self):
-        redis_graph = Graph('printing', self.r)
+        redis_graph = Graph('stringify', self.r)
 
-        john = Node(label='person', properties={'name': 'John Doe', 'age': 33, 'gender': 'male', 'status': 'single'})
+        john = Node(alias='a', label='person',
+                    properties={'name': 'John Doe', 'age': 33, 'gender': 'male', 'status': 'single'})
         redis_graph.add_node(john)
-        japan = Node(label='country', properties={'name': 'Japan'})
+        japan = Node(alias='b', label='country', properties={'name': 'Japan'})
 
         redis_graph.add_node(japan)
         edge = Edge(john, 'visited', japan, properties={'purpose': 'pleasure'})
         redis_graph.add_edge(edge)
 
+        self.assertEqual(str(john),
+                         """(a:person{name:"John Doe",age:33,gender:"male",status:"single"})""")
+        self.assertEqual(str(edge),
+                         """(a:person{name:"John Doe",age:33,gender:"male",status:"single"})""" +
+                         """-[:visited{purpose:"pleasure"}]->""" +
+                         """(b:country{name:"Japan"})""")
+        self.assertEqual(str(japan), """(b:country{name:"Japan"})""")
+
         redis_graph.commit()
 
         query = """MATCH (p:person)-[v:visited {purpose:"pleasure"}]->(c:country)
-        				   RETURN p, v, c"""
+                RETURN p, v, c"""
 
         result = redis_graph.query(query)
-
         person = result.result_set[0][0]
         visit = result.result_set[0][1]
         country = result.result_set[0][2]
@@ -133,5 +139,8 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(str(visit), """()-[:visited{purpose:"pleasure"}]->()""")
         self.assertEqual(str(country), """(:country{name:"Japan"})""")
 
+        redis_graph.delete()
+
+
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -107,5 +107,31 @@ class TestStringMethods(unittest.TestCase):
         # All done, remove graph.
         redis_graph.delete()
 
+    def test_printing_query_result(self):
+        redis_graph = Graph('printing', self.r)
+
+        john = Node(label='person', properties={'name': 'John Doe', 'age': 33, 'gender': 'male', 'status': 'single'})
+        redis_graph.add_node(john)
+        japan = Node(label='country', properties={'name': 'Japan'})
+
+        redis_graph.add_node(japan)
+        edge = Edge(john, 'visited', japan, properties={'purpose': 'pleasure'})
+        redis_graph.add_edge(edge)
+
+        redis_graph.commit()
+
+        query = """MATCH (p:person)-[v:visited {purpose:"pleasure"}]->(c:country)
+        				   RETURN p, v, c"""
+
+        result = redis_graph.query(query)
+
+        person = result.result_set[0][0]
+        visit = result.result_set[0][1]
+        country = result.result_set[0][2]
+
+        self.assertEqual(str(person), """(:person{name:"John Doe",age:33,gender:"male",status:"single"})""")
+        self.assertEqual(str(visit), """()-[:visited{purpose:"pleasure"}]->()""")
+        self.assertEqual(str(country), """(:country{name:"Japan"})""")
+
 if __name__ == '__main__':
 	unittest.main()

--- a/test.py
+++ b/test.py
@@ -107,7 +107,7 @@ class TestStringMethods(unittest.TestCase):
         # All done, remove graph.
         redis_graph.delete()
 
-    def test_printing_query_result(self):
+    def test_stringify_query_result(self):
         redis_graph = Graph('printing', self.r)
 
         john = Node(label='person', properties={'name': 'John Doe', 'age': 33, 'gender': 'male', 'status': 'single'})


### PR DESCRIPTION
The original code does not support `str()` of `Edge` if the `src_node` and `dest_node` fields are not `Node`. However, the `Edge` returned from the `query` have `int` values in both `src_node` and `dest_node` fields.

I modify `__str__()`, so that it will print `()` if the `src_node` and `dest_node ` are not `Node` instances.


This PR is developed based on my last PR request #58 .