### PR TITLE
resolving type error in execution_plan_to_string

### DIFF
--- a/redisgraph/graph.py
+++ b/redisgraph/graph.py
@@ -131,7 +131,7 @@ class Graph(object):
         return QueryResult(self, response)
 
     def _execution_plan_to_string(self, plan):
-        return "\n".join(plan)
+        return b"\n".join(plan)
 
     def execution_plan(self, query):
         """


### PR DESCRIPTION
This fixes "TypeError: sequence item 0: expected str instance, bytes found" on line 134, in _execution_plan_to_string function in graph.py. The error occurred on python 3.6 (Ubuntu 18.04).