### PR TITLE
Added release automation (creates drafts automatically and pushes to pypi on release)

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,21 @@
+name-template: 'Version $NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/check-pypi.yml
+++ b/.github/workflows/check-pypi.yml
@@ -1,0 +1,28 @@
+
+name: Check if required secrets are set to publish to Pypi
+
+on: push
+
+jobs:
+  checksecret:
+    name: check if PYPI_TOKEN and TESTPYPI_TOKEN are set in github secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PYPI_TOKEN
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if ${{ env.PYPI_TOKEN == '' }} ; then
+            echo "PYPI_TOKEN secret is not set"
+            exit 1
+          fi
+      - name: Check TESTPYPI_TOKEN
+        env:
+          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+        run: |
+          if ${{ env.TESTPYPI_TOKEN == '' }} ; then
+            echo "TESTPYPI_TOKEN secret is not set"
+            exit 1
+          fi
+
+

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,50 @@
+name: Publish Pypi
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 2.7
+
+      - name: Install twine
+        run: |
+            pip install twine
+
+      - name: Install wheel
+        run: |
+            pip install wheel
+
+      - name: Create a source distribution
+        run: |
+          python setup.py sdist
+
+      - name: Create a wheel
+        run: |
+            python setup.py bdist_wheel
+
+      - name: Create a .pypirc
+        run: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = ${{ secrets.PYPI_TOKEN }}" >> ~/.pypirc
+            echo -e "[testpypi]" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = ${{ secrets.TESTPYPI_TOKEN }}" >> ~/.pypirc
+
+      - name: Publish to Test PyPI
+        if: github.event_name == 'release'
+        run: |
+          twine upload --skip-existing -r testpypi dist/*
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release'
+        run: |
+          twine upload -r pypi dist/*

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+           config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR simplifies the release process using github actions. It follows the same approach as [redistimeseries-py](https://github.com/RedisTimeSeries/redistimeseries-py/tree/master/.github).

## Release drafts
This PR enables automating the release draft process. On every commit to master ( and depending on the tags the PR is classified as feature, bug-fixes or maintenance). We can also ignore PRs from the release if the PR has the `skip-changelog` label.

## Automatic release to PyPi
We need to ensure that the secrets are present prior releasing ( that check action is run on every commit )
secrets required (cc @gkorland):

- `TESTPYPI_TOKEN`
- `PYPI_TOKEN`
