### PR TITLE
Switch circle CI to tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
               circleci step halt
             fi
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/python:3.6.1
 
@@ -28,53 +28,41 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      - run:
+          name: Install tox
+          command: pip install tox
 
       - run:
-          name: install dependencies
-          command: |
-            python -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install codecov
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          name: Test package build
+          command: tox -e sdist
 
       - run:
-          name: test dist
-          command: python setup.py sdist
+          name: Run code styles
+          command: tox -e pep8
 
       - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            coverage run tests/functional/test_all.py
+          name: Run unittest with coverage
+          command: tox -e cover
+
+      - run:
+          name: Run functional tests
+          command: tox -e func
 
       - early_return_for_forked_pull_requests
 
       - run:
           name: codecove
           command: |
-            . venv/bin/activate
-            codecov
+            . .tox/func/bin/activate
+            codecov --file .tox/cover/report/coverage.xml --name ${CODECOV_NAME}-unittests
+            codecov --file .tox/func/report/coverage.xml --name ${CODECOV_NAME}-functional
 
-   #   - store_artifacts:
-   #       path: test-reports
-   #       destination: test-reports
 
 workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - test
   nightly:
     triggers:
       - schedule:
@@ -84,4 +72,4 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - test

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,5 @@ pytest-html
 
 testtools>=1.4.0
 mock
+
+codecov

--- a/tox.ini
+++ b/tox.ini
@@ -32,13 +32,17 @@ basepython = python3.7
 basepython = python3.8
 
 [testenv:cover]
-commands = py.test --cov=redisgraph tests/unit/ --cov-report=html:{envdir}/report/
+commands = py.test --cov=redisgraph tests/unit/ --cov-report=xml:{envdir}/report/coverage.xml --cov-report=html:{envdir}/report/html
 
 [testenv:func]
-commands = py.test --cov=redisgraph tests/functional/ --cov-report=html:{envdir}/report/
+commands = py.test --cov=redisgraph tests/functional/ --cov-report=xml:{envdir}/report/coverage.xml --cov-report=html:{envdir}/report/html
 
 [testenv:venv]
 commands = {posargs}
+
+[testenv:sdist]
+deps =
+commands = python setup.py sdist
 
 [flake8]
 show-source = true


### PR DESCRIPTION
It makes sense to use the same technologies locally and in CI
as it simplifies local debugging and verifing changes

Before this patch we did run sdist (bulding package) and functional
tests in CI and we were uploading coverage report to covecod

After this PR we are adding code style jobs, unittests with coverage
as well as keeping old jobs in place (but run through tox)

As well now we have 2 reports to upload one for functional tests
one for unittests