### PR TITLE
Fall back to GRAPH.QUERY when `GRAPH.RO_QUERY` is not available.

### DIFF
--- a/redisgraph/graph.py
+++ b/redisgraph/graph.py
@@ -177,6 +177,11 @@ class Graph:
         except redis.exceptions.ResponseError as e:
             if "wrong number of arguments" in str(e):
                 print("Note: RedisGraph Python requires server version 2.2.8 or above")
+            if "unknown command" in str(e):
+                # `GRAPH.RO_QUERY` is unavailable in older versions.
+                command[0] = "GRAPH.QUERY"
+                response = self.redis_con.execute_command(*command)
+                return QueryResult(self, response)
             raise e
         except VersionMismatchException as e:
             # client view over the graph schema is out of sync

--- a/redisgraph/graph.py
+++ b/redisgraph/graph.py
@@ -177,11 +177,9 @@ class Graph:
         except redis.exceptions.ResponseError as e:
             if "wrong number of arguments" in str(e):
                 print("Note: RedisGraph Python requires server version 2.2.8 or above")
-            if "unknown command" in str(e):
+            if "unknown command" in str(e) and read_only:
                 # `GRAPH.RO_QUERY` is unavailable in older versions.
-                command[0] = "GRAPH.QUERY"
-                response = self.redis_con.execute_command(*command)
-                return QueryResult(self, response)
+                return self.query(q, params, timeout, read_only=False)
             raise e
         except VersionMismatchException as e:
             # client view over the graph schema is out of sync


### PR DESCRIPTION
Fix: #123 

`GRAPH.RO_QUERY` is unavailable in older versions. So fallback to GRAPH.QUERY when the command is not found.

While there's a way to always use `GRAPH.QUERY` by setting `read_only` to `False`, methods that try to fetch the labels and other properties are hardcoded to `True`.

```python
    def labels(self):
        return self.call_procedure("db.labels", read_only=True).result_set

    def relationshipTypes(self):
        return self.call_procedure("db.relationshipTypes", read_only=True).result_set

    def propertyKeys(self):
        return self.call_procedure("db.propertyKeys", read_only=True).result_set
```

While we can have a param `read_only` to the above methods, introducing the same would actually change many methods that is calling the above methods directly or indirectly to have `read_only` param and that's huge. 

**So checking for unknown command while executing the query makes it a simple fix.**