### PR TITLE
close connection on graph destruction

### DIFF
--- a/redisgraph/graph.py
+++ b/redisgraph/graph.py
@@ -10,31 +10,22 @@ class Graph:
     Graph, collection of nodes and edges.
     """
 
-    def __init__(self, name, redis_con=None, host=None, port=None, password=None):
+    def __init__(self, name, redis_con=None, host='localhost', port=6379, password=None):
         """
         Create a new graph.
         """
         self.name = name                 # Graph key
         if redis_con is not None:
-            self.close_con = False
             self.redis_con = redis_con
-        elif host is not None and port is not None:
-            self.close_con = True
-            self.redis_con = redis.Redis(host, port, password=password)
         else:
-            raise RuntimeError(
-                "The constructor must have redis_con argument or host and port."
-            )
+            self.redis_con = redis.Redis(host, port, password=password)
+
         self.nodes = {}
         self.edges = []
         self._labels = []                # List of node labels.
         self._properties = []            # List of properties.
         self._relationshipTypes = []     # List of relation types.
         self.version = 0                 # Graph version
-
-    def __del__(self):
-        if hasattr(self, 'close_con') and self.close_con:            # Close the connection only if it was
-            self.redis_con.close()                                   # created by the constructor.
 
     def _clear_schema(self):
         self._labels = []

--- a/redisgraph/graph.py
+++ b/redisgraph/graph.py
@@ -10,18 +10,31 @@ class Graph:
     Graph, collection of nodes and edges.
     """
 
-    def __init__(self, name, redis_con):
+    def __init__(self, name, redis_con=None, host=None, port=None, password=None):
         """
         Create a new graph.
         """
         self.name = name                 # Graph key
-        self.redis_con = redis_con
+        if redis_con is not None:
+            self.close_con = False
+            self.redis_con = redis_con
+        elif host is not None and port is not None:
+            self.close_con = True
+            self.redis_con = redis.Redis(host, port, password=password)
+        else:
+            raise RuntimeError(
+                "The constructor must have redis_con argument or host and port."
+            )
         self.nodes = {}
         self.edges = []
         self._labels = []                # List of node labels.
         self._properties = []            # List of properties.
         self._relationshipTypes = []     # List of relation types.
         self.version = 0                 # Graph version
+
+    def __del__(self):
+        if hasattr(self, 'close_con') and self.close_con:            # Close the connection only if it was
+            self.redis_con.close()                                   # created by the constructor.
 
     def _clear_schema(self):
         self._labels = []

--- a/tests/functional/test_all.py
+++ b/tests/functional/test_all.py
@@ -46,6 +46,19 @@ class TestStringMethods(base.TestCase):
         # All done, remove graph.
         redis_graph.delete()
 
+    def test_graph_connection(self):
+        connections = len(self.r.client_list())
+        redis_graph = Graph('social', self.r)
+        del redis_graph
+        self.assertTrue(self.r.ping())
+        self.assertTrue(len(self.r.client_list()) == connections)
+
+        new_graph = Graph('social-new')
+        self.assertTrue(new_graph.redis_con.ping())
+        self.assertTrue(len(self.r.client_list()) == connections + 1)
+        del new_graph
+        self.assertTrue(len(self.r.client_list()) == connections)
+
     def test_array_functions(self):
         redis_graph = Graph('social', self.r)
 


### PR DESCRIPTION
Close connection on graph object destruction only when the connection was created by the constructor (bypassing host and port)