### PR TITLE
Escape backslashes in parameter strings.

### DIFF
--- a/redisgraph/util.py
+++ b/redisgraph/util.py
@@ -25,6 +25,7 @@ def quote_string(v):
     if len(v) == 0:
         return '""'
 
+    v = v.replace('\\', '\\\\')
     v = v.replace('"', '\\"')
 
     return '"{}"'.format(v)

--- a/tests/functional/test_all.py
+++ b/tests/functional/test_all.py
@@ -101,6 +101,29 @@ class TestStringMethods(base.TestCase):
         # All done, remove graph.
         redis_graph.delete()
 
+    def test_properties_with_escapes(self):
+        redis_graph = Graph('props', self.r)
+
+        message = r'This raw string has \ a backslash character in it.'
+        params = {'message': message}
+        query = """CREATE (:Foo {message: $message})"""
+        redis_graph.query(query, params)
+
+        query = """MATCH (u:Foo) RETURN u.message"""
+        result = redis_graph.query(query)
+        self.assertEqual(result.result_set[0][0], message)
+
+        message = r'This raw string has \" a quote preceded by backslash.'
+        params = {'message': message}
+        query = """CREATE (:Bar {message: $message})"""
+        redis_graph.query(query, params)
+
+        query = """MATCH (u:Bar) RETURN u.message"""
+        result = redis_graph.query(query)
+        self.assertEqual(result.result_set[0][0], message)
+
+        redis_graph.delete()
+
     def test_param(self):
         redis_graph = Graph('params', self.r)
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -12,11 +12,12 @@ class TestUtils(base.TestCase):
 
     def test_quote_string(self):
         self.assertEqual(util.quote_string(10), 10)
-        self.assertEqual(util.quote_string("abc"), '"abc"')
-        self.assertEqual(util.quote_string(""), '""')
-        self.assertEqual(util.quote_string('\"'), '"\\\""')
-        self.assertEqual(util.quote_string('"'), '"\\""')
-        self.assertEqual(util.quote_string('a"a'), '"a\\"a"')
+        self.assertEqual(util.quote_string('abc'), '"abc"')
+        self.assertEqual(util.quote_string(''), '""')
+        self.assertEqual(util.quote_string('"'), r'"\""')
+        self.assertEqual(util.quote_string(r'foo \ bar'), r'"foo \\ bar"')
+        self.assertEqual(util.quote_string(r'foo \" bar'), r'"foo \\\" bar"')
+        self.assertEqual(util.quote_string('a"a'), r'"a\"a"')
 
     def test_stringify_param_value(self):
         cases = [


### PR DESCRIPTION
Fixes #139 

I added the functional test `tests.functional.test_all.TestStringMethods.test_properties_with_escapes()` which demonstrates that, when you set a property string containing backslash or quotation mark, you get the same string back after reading.

I also rewrote the unit test `tests.unit.test_util.TestUtils.test_quote_string()` using raw strings, which I think makes the test much easier to read and understand.